### PR TITLE
Enable py311 support

### DIFF
--- a/.github/workflows/pip-publish.yml
+++ b/.github/workflows/pip-publish.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install pypa/build
       run: >-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: 'recursive'
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -57,6 +57,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python }}

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 sphinx:
    configuration: docs/conf.py
 formats:

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ lint: ## Check code style
 .PHONY: test
 test: ## Run tests quickly with the default Python
 	@echo "+ $@"
-	@nox -p 3.10
+	@nox -p 3.11
 
 .PHONY: test-all
 test-all: ## Run tests on every Python version with tox
@@ -76,7 +76,7 @@ test-all: ## Run tests on every Python version with tox
 .PHONY: coverage
 coverage: ## Check code coverage quickly with the default Python
 	@echo "+ $@"
-	@nox -s tests -p 3.10
+	@nox -s tests -p 3.11
 	@$(BROWSER) htmlcov/index.html
 
 .PHONY: docs

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ to make it as good as possible!
 
 - Cross-platform: Windows, Mac, and Linux are officially supported.
 - You don't have to know/write Python code to use Cookiecutter.
-- Works with Python 3.7, 3.8, 3.9., 3.10
+- Works with Python 3.7, 3.8, 3.9., 3.10, 3.11
 - Project templates can be in any programming language or markup format:
   Python, JavaScript, Ruby, CoffeeScript, RST, Markdown, CSS, HTML, you name it.
   You can use multiple languages in the same project template.

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,14 +17,14 @@ def base_install(session):
     return session
 
 
-@nox.session(python="3.10")
+@nox.session(python="3.11")
 def lint(session):
     """Run linting check locally."""
     session.install("pre-commit")
     session.run("pre-commit", "run", "-a")
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
 def tests(session):
     """Run test suite with pytest."""
     session = base_install(session)
@@ -37,20 +37,20 @@ def tests(session):
     )
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
 def safety_tests(session):
     """Run safety tests."""
     session = base_install(session)
     session.run("safety", "check", "--full-report")
 
 
-@nox.session(python="3.10")
+@nox.session(python="3.11")
 def documentation_tests(session):
     """Run documentation tests."""
     return docs(session, batch_run=True)
 
 
-@nox.session(python="3.10")
+@nox.session(python="3.11")
 def docs(session, batch_run: bool = False):
     """Build the documentation or serve documentation interactively."""
     shutil.rmtree(Path("docs").joinpath("_build"), ignore_errors=True)

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python",

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py38
     py39
     py310
+    py311
 minversion = 3.14.2
 requires =
     virtualenv >= 20.4.5


### PR DESCRIPTION
This PR is forked from the original PR -  https://github.com/cookiecutter/cookiecutter/pull/1778
Address #15 

enable py311 pipelines
expose py311 support in metadata

