### PR TITLE
Fixing Carriage Return Line Feed (CRLF) order in docs

### DIFF
--- a/docs/advanced/new_line_characters.rst
+++ b/docs/advanced/new_line_characters.rst
@@ -14,7 +14,7 @@ This allow template developers to have both types of files in the same template.
 Developers should correctly configure their ``.gitattributes`` file to avoid line-end character overwrite by git.
 
 The special template variable ``_new_lines`` enforces a specific line ending.
-Acceptable variables: ``'\n\r'`` for CRLF and ``'\n'`` for POSIX.
+Acceptable variables: ``'\r\n'`` for CRLF and ``'\n'`` for POSIX.
 
 Here is example how to force line endings to CRLF on any deployment:
 
@@ -22,5 +22,5 @@ Here is example how to force line endings to CRLF on any deployment:
 
     {
         "project_slug": "sample",
-        "_new_lines": "\n\r"
+        "_new_lines": "\r\n"
     }


### PR DESCRIPTION
Addresses #28

This PR has been ported over from the Cookiecutter project.
For more details see: https://github.com/cookiecutter/cookiecutter/pull/1793