### PR TITLE
Add support to recursively cloning Git submodules

### DIFF
--- a/cookieninja/cli.py
+++ b/cookieninja/cli.py
@@ -90,6 +90,11 @@ def list_installed_templates(default_config, passed_config_file):
     "for advanced repositories with multi templates in it",
 )
 @click.option(
+    '--recurse-submodules', help='recursively checkout git submodules',
+    is_flag=True,
+    default=False
+)
+@click.option(
     "-v", "--verbose", is_flag=True, help="Print debug information", default=False
 )
 @click.option(
@@ -157,6 +162,7 @@ def main(
     extra_context,
     no_input,
     checkout,
+    recurse_submodules,
     verbose,
     replay,
     overwrite_if_exists,
@@ -205,6 +211,7 @@ def main(
             template,
             checkout,
             no_input,
+            recurse_submodules=recurse_submodules,
             extra_context=extra_context,
             replay=replay,
             overwrite_if_exists=overwrite_if_exists,

--- a/cookieninja/cli.py
+++ b/cookieninja/cli.py
@@ -90,8 +90,8 @@ def list_installed_templates(default_config, passed_config_file):
     "for advanced repositories with multi templates in it",
 )
 @click.option(
-    '--recurse-submodules',
-    help='recursively checkout git submodules',
+    "--recurse-submodules",
+    help="recursively checkout git submodules",
     is_flag=True,
     default=False,
 )

--- a/cookieninja/cli.py
+++ b/cookieninja/cli.py
@@ -90,9 +90,10 @@ def list_installed_templates(default_config, passed_config_file):
     "for advanced repositories with multi templates in it",
 )
 @click.option(
-    '--recurse-submodules', help='recursively checkout git submodules',
+    '--recurse-submodules',
+    help='recursively checkout git submodules',
     is_flag=True,
-    default=False
+    default=False,
 )
 @click.option(
     "-v", "--verbose", is_flag=True, help="Print debug information", default=False

--- a/cookieninja/main.py
+++ b/cookieninja/main.py
@@ -25,6 +25,7 @@ def cookiecutter(
     template,
     checkout=None,
     no_input=False,
+    recurse_submodules=False,
     extra_context=None,
     replay=None,
     overwrite_if_exists=False,
@@ -46,6 +47,7 @@ def cookiecutter(
     :param no_input: Do not prompt for user input.
         Use default values for template parameters taken from `cookiecutter.json`, user
         config and `extra_dict`. Force a refresh of cached resources.
+    :param recurse_submodules: Clone submodules if set to `True`
     :param extra_context: A dictionary of context that overrides default
         and user configuration.
     :param replay: Do not prompt for input, instead read from saved json. If
@@ -80,6 +82,7 @@ def cookiecutter(
         clone_to_dir=config_dict["cookiecutters_dir"],
         checkout=checkout,
         no_input=no_input,
+        recurse_submodules=recurse_submodules,
         password=password,
         directory=directory,
     )

--- a/cookieninja/repository.py
+++ b/cookieninja/repository.py
@@ -69,6 +69,7 @@ def determine_repo_dir(
     clone_to_dir,
     checkout,
     no_input,
+    recurse_submodules=False,
     password=None,
     directory=None,
 ):
@@ -87,6 +88,7 @@ def determine_repo_dir(
     :param checkout: The branch, tag or commit ID to checkout after clone.
     :param no_input: Do not prompt for user input and eventually force a refresh of
         cached resources.
+    :param recurse_submodules: Clone submodules if set to `True`
     :param password: The password to use when extracting the repository.
     :param directory: Directory within repo where cookiecutter.json lives.
     :return: A tuple containing the cookiecutter template directory, and
@@ -110,6 +112,7 @@ def determine_repo_dir(
         cloned_repo = clone(
             repo_url=template,
             checkout=checkout,
+            recurse_submodules=recurse_submodules,
             clone_to_dir=clone_to_dir,
             no_input=no_input,
         )

--- a/cookieninja/vcs.py
+++ b/cookieninja/vcs.py
@@ -92,21 +92,21 @@ def clone(
     repo_name = os.path.split(repo_url)[1]
 
     repo_args = {
-        'git': ['git', 'clone'],
-        'hg': ['hg', 'clone'],
+        "git": ["git", "clone"],
+        "hg": ["hg", "clone"],
     }
     clone_command = repo_args[repo_type]  # avoid warning if defined in if-elif
-    if repo_type == 'git':
+    if repo_type == "git":
         # git repository.
-        repo_name = repo_name.split(':')[-1].rsplit('.git')[0]
+        repo_name = repo_name.split(":")[-1].rsplit(".git")[0]
         repo_dir = os.path.normpath(os.path.join(clone_to_dir, repo_name))
         if recurse_submodules:
-            clone_command.append('--recurse-submodules')
+            clone_command.append("--recurse-submodules")
     else:
         # hg repository.
         repo_dir = os.path.normpath(os.path.join(clone_to_dir, repo_name))
     clone_command.append(repo_url)
-    logger.debug(f'repo_dir is {repo_dir}')
+    logger.debug(f"repo_dir is {repo_dir}")
 
     if os.path.isdir(repo_dir):
         clone = prompt_and_delete(repo_dir, no_input=no_input)

--- a/cookieninja/vcs.py
+++ b/cookieninja/vcs.py
@@ -66,6 +66,7 @@ def clone(
     no_input: bool = False,
 ):
     """Clone a repo to the current directory.
+
     :param repo_url: Repo URL of unknown type.
     :param checkout: The branch, tag or commit ID to checkout after clone.
     :param recurse_submodules: Clone submodules if set to `True`
@@ -89,17 +90,20 @@ def clone(
 
     repo_url = repo_url.rstrip("/")
     repo_name = os.path.split(repo_url)[1]
-    _repo_args = {'git': ['git', 'clone'],
-                  'hg': ['hg', 'clone'],
-                  }
-    clone_command = _repo_args[repo_type] # avoid warnign if defined in if-elif
+
+    repo_args = {
+        'git': ['git', 'clone'],
+        'hg': ['hg', 'clone'],
+    }
+    clone_command = repo_args[repo_type]  # avoid warning if defined in if-elif
     if repo_type == 'git':
+        # git repository.
         repo_name = repo_name.split(':')[-1].rsplit('.git')[0]
         repo_dir = os.path.normpath(os.path.join(clone_to_dir, repo_name))
         if recurse_submodules:
             clone_command.append('--recurse-submodules')
-
-    elif repo_type == 'hg':
+    else:
+        # hg repository.
         repo_dir = os.path.normpath(os.path.join(clone_to_dir, repo_name))
     clone_command.append(repo_url)
     logger.debug(f'repo_dir is {repo_dir}')

--- a/cookieninja/vcs.py
+++ b/cookieninja/vcs.py
@@ -93,12 +93,19 @@ def clone(
 
     repo_args = {
         "git": ["git", "clone"],
+        "git-remote-codecommit": ["git", "clone"],
         "hg": ["hg", "clone"],
     }
     clone_command = repo_args[repo_type]  # avoid warning if defined in if-elif
-    if repo_type == "git":
+    if "git" == repo_type:
         # git repository.
         repo_name = repo_name.split(":")[-1].rsplit(".git")[0]
+        repo_dir = os.path.normpath(os.path.join(clone_to_dir, repo_name))
+        if recurse_submodules:
+            clone_command.append("--recurse-submodules")
+    elif "git-remote-codecommit" == repo_type:
+        repo_type = "git"
+        repo_name = repo_name.split("@")[-1]
         repo_dir = os.path.normpath(os.path.join(clone_to_dir, repo_name))
         if recurse_submodules:
             clone_command.append("--recurse-submodules")

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -73,6 +73,19 @@ on a local server::
 
     $ cookieninja file://server/folder/project.git
 
+Works with git submodules
+-------------------------
+
+If you have complex structures where different templates need to be
+combined, you could use git submodules in your template. Then, by passing
+the parameter '--recurse-submodules' all submodules from your project will
+be also downloaded allowing you to used them in your project.
+
+    $ cookiecutter hg+https://example.com/repo --recurse-submodules
+
+In addition, one can combine it with post processing functions in order to
+have even more flexibility.
+
 Works with Zip files
 --------------------
 

--- a/tests/repository/test_determine_repo_dir_clones_repo.py
+++ b/tests/repository/test_determine_repo_dir_clones_repo.py
@@ -32,6 +32,7 @@ def test_zipfile_unzip(mocker, template, is_url, user_config_data):
         clone_to_dir=user_config_data["cookiecutters_dir"],
         checkout=None,
         no_input=True,
+        recurse_submodules=False,
         password=None,
     )
 
@@ -75,6 +76,7 @@ def test_repository_url_should_clone(mocker, template_url, user_config_data):
         clone_to_dir=user_config_data["cookiecutters_dir"],
         checkout=None,
         no_input=True,
+        recurse_submodules=False,
     )
 
     mock_clone.assert_called_once_with(
@@ -82,6 +84,7 @@ def test_repository_url_should_clone(mocker, template_url, user_config_data):
         checkout=None,
         clone_to_dir=user_config_data["cookiecutters_dir"],
         no_input=True,
+        recurse_submodules=False,
     )
 
     assert os.path.isdir(project_dir)
@@ -104,6 +107,7 @@ def test_repository_url_with_no_context_file(mocker, template_url, user_config_d
             clone_to_dir=None,
             checkout=None,
             no_input=True,
+            recurse_submodules=False,
         )
 
     assert str(err.value) == (

--- a/tests/repository/test_determine_repo_dir_finds_existing_cookiecutter.py
+++ b/tests/repository/test_determine_repo_dir_finds_existing_cookiecutter.py
@@ -39,6 +39,7 @@ def test_should_find_existing_cookiecutter(
         abbreviations={},
         clone_to_dir=user_config_data["cookiecutters_dir"],
         checkout=None,
+        recurse_submodules=False,
         no_input=True,
     )
 

--- a/tests/repository/test_determine_repo_dir_finds_subdirectories.py
+++ b/tests/repository/test_determine_repo_dir_finds_subdirectories.py
@@ -58,7 +58,7 @@ def test_local_repo_typo(template, user_config_data, cloned_cookiecutter_path):
             checkout=None,
             no_input=True,
             recurse_submodules=False,
-            directory='wrong-dir',
+            directory="wrong-dir",
         )
 
     wrong_full_cookiecutter_path = os.path.join(

--- a/tests/repository/test_determine_repo_dir_finds_subdirectories.py
+++ b/tests/repository/test_determine_repo_dir_finds_subdirectories.py
@@ -39,6 +39,7 @@ def test_should_find_existing_cookiecutter(
         abbreviations={},
         clone_to_dir=user_config_data["cookiecutters_dir"],
         checkout=None,
+        recurse_submodules=False,
         no_input=True,
         directory="my-dir",
     )
@@ -56,7 +57,8 @@ def test_local_repo_typo(template, user_config_data, cloned_cookiecutter_path):
             clone_to_dir=user_config_data["cookiecutters_dir"],
             checkout=None,
             no_input=True,
-            directory="wrong-dir",
+            recurse_submodules=False,
+            directory='wrong-dir',
         )
 
     wrong_full_cookiecutter_path = os.path.join(

--- a/tests/repository/test_determine_repository_should_use_local_repo.py
+++ b/tests/repository/test_determine_repository_should_use_local_repo.py
@@ -14,6 +14,7 @@ def test_finds_local_repo(tmp_path):
         abbreviations={},
         clone_to_dir=str(tmp_path),
         checkout=None,
+        recurse_submodules=False,
         no_input=True,
     )
 
@@ -31,6 +32,7 @@ def test_local_repo_with_no_context_raises(tmp_path):
             abbreviations={},
             clone_to_dir=str(tmp_path),
             checkout=None,
+            recurse_submodules=False,
             no_input=True,
         )
 
@@ -55,6 +57,7 @@ def test_local_repo_typo(tmp_path):
             abbreviations={},
             clone_to_dir=str(tmp_path),
             checkout=None,
+            recurse_submodules=False,
             no_input=True,
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,11 +98,12 @@ def test_cli_verbose(cli_runner):
 
 def test_user_config_recurse_submodules(mocker, cli_runner, user_config_path):
     """Test cli invocation works with `recurse-submodules` option."""
-    mock_cookiecutter = mocker.patch('cookiecutter.cli.cookiecutter')
+    mock_cookiecutter = mocker.patch('cookieninja.cli.cookiecutter')
 
     template_path = 'tests/fake-repo-pre/'
-    result = cli_runner(template_path, '--config-file', user_config_path,
-                        '--recurse-submodules')
+    result = cli_runner(
+        template_path, '--config-file', user_config_path, '--recurse-submodules'
+    )
 
     assert result.exit_code == 0
     mock_cookiecutter.assert_called_once_with(
@@ -120,6 +121,7 @@ def test_user_config_recurse_submodules(mocker, cli_runner, user_config_path):
         password=None,
         directory=None,
         accept_hooks=True,
+        keep_project_on_failure=False,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,11 +98,11 @@ def test_cli_verbose(cli_runner):
 
 def test_user_config_recurse_submodules(mocker, cli_runner, user_config_path):
     """Test cli invocation works with `recurse-submodules` option."""
-    mock_cookiecutter = mocker.patch('cookieninja.cli.cookiecutter')
+    mock_cookiecutter = mocker.patch("cookieninja.cli.cookiecutter")
 
-    template_path = 'tests/fake-repo-pre/'
+    template_path = "tests/fake-repo-pre/"
     result = cli_runner(
-        template_path, '--config-file', user_config_path, '--recurse-submodules'
+        template_path, "--config-file", user_config_path, "--recurse-submodules"
     )
 
     assert result.exit_code == 0
@@ -114,7 +114,7 @@ def test_user_config_recurse_submodules(mocker, cli_runner, user_config_path):
         replay=False,
         overwrite_if_exists=False,
         skip_if_file_exists=False,
-        output_dir='.',
+        output_dir=".",
         config_file=user_config_path,
         default_config=False,
         extra_context=None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,6 +96,33 @@ def test_cli_verbose(cli_runner):
     assert "Project name: **Fake Project**" in content
 
 
+def test_user_config_recurse_submodules(mocker, cli_runner, user_config_path):
+    """Test cli invocation works with `recurse-submodules` option."""
+    mock_cookiecutter = mocker.patch('cookiecutter.cli.cookiecutter')
+
+    template_path = 'tests/fake-repo-pre/'
+    result = cli_runner(template_path, '--config-file', user_config_path,
+                        '--recurse-submodules')
+
+    assert result.exit_code == 0
+    mock_cookiecutter.assert_called_once_with(
+        template_path,
+        None,
+        False,
+        recurse_submodules=True,
+        replay=False,
+        overwrite_if_exists=False,
+        skip_if_file_exists=False,
+        output_dir='.',
+        config_file=user_config_path,
+        default_config=False,
+        extra_context=None,
+        password=None,
+        directory=None,
+        accept_hooks=True,
+    )
+
+
 @pytest.mark.usefixtures("remove_fake_project_dir")
 def test_cli_replay(mocker, cli_runner):
     """Test cli invocation display log with `verbose` and `replay` flags."""
@@ -109,6 +136,7 @@ def test_cli_replay(mocker, cli_runner):
         template_path,
         None,
         False,
+        recurse_submodules=False,
         replay=True,
         overwrite_if_exists=False,
         skip_if_file_exists=False,
@@ -136,6 +164,7 @@ def test_cli_replay_file(mocker, cli_runner):
         template_path,
         None,
         False,
+        recurse_submodules=False,
         replay="~/custom-replay-file",
         overwrite_if_exists=False,
         skip_if_file_exists=False,
@@ -172,6 +201,7 @@ def test_cli_exit_on_noinput_and_replay(mocker, cli_runner):
         template_path,
         None,
         True,
+        recurse_submodules=False,
         replay=True,
         overwrite_if_exists=False,
         skip_if_file_exists=False,
@@ -208,6 +238,7 @@ def test_run_cookiecutter_on_overwrite_if_exists_and_replay(
         template_path,
         None,
         False,
+        recurse_submodules=False,
         replay=True,
         overwrite_if_exists=True,
         skip_if_file_exists=False,
@@ -265,6 +296,7 @@ def test_cli_output_dir(mocker, cli_runner, output_dir_flag, output_dir):
         template_path,
         None,
         False,
+        recurse_submodules=False,
         replay=False,
         overwrite_if_exists=False,
         skip_if_file_exists=False,
@@ -310,6 +342,7 @@ def test_user_config(mocker, cli_runner, user_config_path):
         template_path,
         None,
         False,
+        recurse_submodules=False,
         replay=False,
         overwrite_if_exists=False,
         skip_if_file_exists=False,
@@ -341,6 +374,7 @@ def test_default_user_config_overwrite(mocker, cli_runner, user_config_path):
         template_path,
         None,
         False,
+        recurse_submodules=False,
         replay=False,
         overwrite_if_exists=False,
         skip_if_file_exists=False,
@@ -367,6 +401,7 @@ def test_default_user_config(mocker, cli_runner):
         template_path,
         None,
         False,
+        recurse_submodules=False,
         replay=False,
         overwrite_if_exists=False,
         skip_if_file_exists=False,
@@ -633,6 +668,7 @@ def test_cli_accept_hooks(
         None,
         False,
         replay=False,
+        recurse_submodules=False,
         overwrite_if_exists=False,
         output_dir=output_dir,
         config_file=None,

--- a/tests/vcs/test_clone.py
+++ b/tests/vcs/test_clone.py
@@ -221,6 +221,10 @@ def test_clone_unknown_subprocess_error(mocker, clone_dir):
             ["git", "clone", "--recurse-submodules", "https://github.com/foo/bar"],
         ),
         (
+            "codecommit://cookiecutter",
+            ["git", "clone", "--recurse-submodules", "codecommit://cookiecutter"],
+        ),
+        (
             "https://bitbucket.org/foo/bar",
             ["hg", "clone", "https://bitbucket.org/foo/bar"],
         ),

--- a/tests/vcs/test_clone.py
+++ b/tests/vcs/test_clone.py
@@ -214,15 +214,15 @@ def test_clone_unknown_subprocess_error(mocker, clone_dir):
 
 
 @pytest.mark.parametrize(
-    'url, expected_clone_args',
+    "url, expected_clone_args",
     [
         (
-            'https://github.com/foo/bar',
-            ['git', 'clone', '--recurse-submodules', 'https://github.com/foo/bar'],
+            "https://github.com/foo/bar",
+            ["git", "clone", "--recurse-submodules", "https://github.com/foo/bar"],
         ),
         (
-            'https://bitbucket.org/foo/bar',
-            ['hg', 'clone', 'https://bitbucket.org/foo/bar'],
+            "https://bitbucket.org/foo/bar",
+            ["hg", "clone", "https://bitbucket.org/foo/bar"],
         ),
     ],
 )
@@ -233,10 +233,10 @@ def test_clone_recurse_submodules(mocker, clone_dir, url, expected_clone_args):
     This test should result in the `--recurse-submodules` flag being added to the
     `git clone` commands, and no flags added to `hg clone` commands.
     """
-    mocker.patch('cookieninja.vcs.is_vcs_installed', autospec=True, return_value=True)
+    mocker.patch("cookieninja.vcs.is_vcs_installed", autospec=True, return_value=True)
 
     mock_subprocess = mocker.patch(
-        'cookieninja.vcs.subprocess.check_output',
+        "cookieninja.vcs.subprocess.check_output",
         autospec=True,
     )
 

--- a/tests/vcs/test_clone.py
+++ b/tests/vcs/test_clone.py
@@ -211,3 +211,44 @@ def test_clone_unknown_subprocess_error(mocker, clone_dir):
             clone_to_dir=str(clone_dir),
             no_input=True,
         )
+
+
+@pytest.mark.parametrize(
+    'url, expected_clone_args',
+    [
+        (
+            'https://github.com/foo/bar',
+            ['git', 'clone', '--recurse-submodules', 'https://github.com/foo/bar'],
+        ),
+        (
+            'https://bitbucket.org/foo/bar',
+            ['hg', 'clone', 'https://bitbucket.org/foo/bar'],
+        ),
+    ],
+)
+def test_clone_recurse_submodules(mocker, clone_dir, url, expected_clone_args):
+    """Tests cloning submodules recursively.
+
+    Tests the fix for issue #48.
+    This test should result in the `--recurse-submodules` flag being added to the
+    `git clone` commands, and no flags added to `hg clone` commands.
+    """
+    mocker.patch('cookieninja.vcs.is_vcs_installed', autospec=True, return_value=True)
+
+    mock_subprocess = mocker.patch(
+        'cookieninja.vcs.subprocess.check_output',
+        autospec=True,
+    )
+
+    vcs.clone(
+        url,
+        recurse_submodules=True,
+        clone_to_dir=clone_dir,
+        no_input=True,
+    )
+
+    mock_subprocess.assert_called_once_with(
+        expected_clone_args,
+        cwd=clone_dir,
+        stderr=subprocess.STDOUT,
+    )


### PR DESCRIPTION
Addresses #48 

This PR has been ported over from the Cookiecutter project.
For more details see: https://github.com/cookiecutter/cookiecutter/pull/1469

Please note that the tests in the `test_clone.py` file where added by me, as coverage was missing.