### PR TITLE
improving test_make_sure_path_exists_correctly_handle_os_error

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -70,6 +70,10 @@ def test_make_sure_path_exists_correctly_handle_os_error(mocker):
         utils.make_sure_path_exists(Path("protected_path"))
     assert str(err.value) == "Unable to create directory at protected_path"
 
+    with pytest.raises(OSError) as err:
+        utils.make_sure_path_exists(Path('invalid\\path'))
+    assert str(err.value) == "Unable to create directory at invalid\\path"
+
 
 def test_work_in(tmp_path):
     """Verify returning to original folder after `utils.work_in` use."""


### PR DESCRIPTION
The test `test_make_sure_path_exists_correctly_handle_os_error` is missing a case when the path is invalid, for example, Path('invalid\\path').

Hope this PR can make this test a bit better.

BTW: I also opened this PR in project cookiecutter.